### PR TITLE
비건타입 수정

### DIFF
--- a/src/main/java/com/app/vple/controller/RecommandRestaurantController.java
+++ b/src/main/java/com/app/vple/controller/RecommandRestaurantController.java
@@ -24,7 +24,7 @@ public class RecommandRestaurantController {
 
     private final RecommandRestaurantService recommandRestaurantService;
 
-    private final int PAGE_SIZE = 20;
+    private final int PAGE_SIZE = 12;
 
     @GetMapping
     public ResponseEntity<?> recommandRestaurantList(

--- a/src/main/java/com/app/vple/domain/RecommandRestaurant.java
+++ b/src/main/java/com/app/vple/domain/RecommandRestaurant.java
@@ -33,10 +33,10 @@ public class RecommandRestaurant {
 
     private Float rating;
 
-    //@Column(nullable = false)
+    @Column(nullable = false)
     private String latitude;
 
-    //@Column(nullable = false)
+    @Column(nullable = false)
     private String longitude;
 
     @Column(nullable = false)
@@ -52,9 +52,6 @@ public class RecommandRestaurant {
 
     @OneToMany(mappedBy = "recommandRestaurant")
     private List<Menu> menus;
-
-    @Enumerated(EnumType.STRING)
-    private VeganType veganType;
 
     @OneToMany(mappedBy = "restaurant")
     private List<RestaurantReview> reviews;

--- a/src/main/java/com/app/vple/domain/dto/RecommandRestaurantDetailDto.java
+++ b/src/main/java/com/app/vple/domain/dto/RecommandRestaurantDetailDto.java
@@ -1,10 +1,10 @@
 package com.app.vple.domain.dto;
 
 import com.app.vple.domain.RecommandRestaurant;
-import com.app.vple.domain.enums.VeganType;
 
 import lombok.Data;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,11 +39,17 @@ public class RecommandRestaurantDetailDto {
 
     private String image;
 
-    private VeganType veganType;
+    private List<String> veganTypes = new ArrayList<String>();
 
-    private List<ReviewDto> reviews;
+    public List<String> veganTypeList(List<String> veganTypes) {
+        for (int i=0; i < this.menus.size(); i++) {
+            String veganType = this.menus.get(i).getVeganType();
 
-    private HashTagDto hashTags;
+            if (!veganTypes.contains(veganType))
+                veganTypes.add(veganType);
+        }
+        return veganTypes;
+    }
 
     public RecommandRestaurantDetailDto(RecommandRestaurant entity) {
         this.id = entity.getId();
@@ -62,8 +68,6 @@ public class RecommandRestaurantDetailDto {
         ).collect(Collectors.toList());
         this.rating = entity.getRating();
         this.image = entity.getImage();
-        this.veganType = entity.getVeganType();
-        this.reviews = entity.getReviews().stream().map(ReviewDto::new).collect(Collectors.toList());
-        this.hashTags = new HashTagDto(entity.getReviews(), false);
+        this.veganTypes = veganTypeList(veganTypes);
     }
 }


### PR DESCRIPTION
관계형 db에서 컬럼이 문자열 리스트가 될 수 없어서 
비건타입을 식당 테이블에서는 컬럼으로 가지지 않고 dto에서 리스트로 만들어 제공하는 것으로 변경했습니다.
중복제거도 추가했습니다.